### PR TITLE
Fix latexmk option in build instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ uplatex main.tex
 dvipdfmx main.dvi
 
 # Or if latexmk is configured for Japanese LaTeX
-latexmk -pdfdvi main.tex
+latexmk main.tex
 
 # Clean build artifacts
 rm -f *.aux *.log *.dvi *.toc *.lof *.lot

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ uplatex main.tex
 dvipdfmx main.dvi
 
 # latexmk使用（設定済みの場合）
-latexmk -pdfdvi main.tex
+latexmk main.tex
 
 # クリーンアップ
 rm -f *.aux *.log *.dvi *.toc


### PR DESCRIPTION
## 修正内容

### latexmkオプションの修正
- Rc files read:
  /Users/toshi/.latexmkrc
  .latexmkrc
Latexmk: This is Latexmk, John Collins, 27 Dec. 2024. Version 4.86a.
No existing .aux file, so I'll make a simple one, and require run of *latex.
Latexmk: applying rule 'latex'...
Rule 'latex':  Reasons for rerun
Category 'other':
  Rerun of 'latex' forced or previously required:
    Reason or flag: 'Initial setup'

------------
Run number 1 of rule 'latex'
------------
------------
Running 'uplatex -halt-on-error -interaction=nonstopmode  -recorder  "main.tex"'
------------
This is e-upTeX, Version 3.141592653-p4.1.2-u2.00-250202-2.6 (utf8.uptex) (TeX Live 2025) (preloaded format=uplatex)
 restricted \write18 enabled.
entering extended mode
(./main.tex
pLaTeX2e <2023-02-14u04>+1, based on
LaTeX2e <2024-11-01> patch level 2
L3 programming layer <2025-01-18>
(/usr/local/texlive/2025/texmf-dist/tex/platex/jsclasses/jsarticle.cls
Document Class: jsarticle 2023/02/23 jsclasses (okumura, texjporg)
(/usr/local/texlive/2025/texmf-dist/tex/platex/jsclasses/jslogo.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics/graphicx.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics/keyval.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics/graphics.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics/trig.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics-cfg/graphics.cfg)
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics-def/dvipdfmx.def)))
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amsmath.sty
For additional information on amsmath, use the `?' option.
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amstext.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amsgen.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amsbsy.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amsopn.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsfonts/amssymb.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsfonts/amsfonts.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/url/url.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/enumitem/enumitem.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/base/textcomp.sty)
(/usr/local/texlive/2025/texmf-dist/tex/platex/japanese-otf/otf.sty
(/usr/local/texlive/2025/texmf-dist/tex/platex/japanese-otf/ajmacros.sty))
(/usr/local/texlive/2025/texmf-dist/tex/platex/pxchfon/pxchfon.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/etoolbox/etoolbox.sty)
(/usr/local/texlive/2025/texmf-dist/tex/platex/pxchfon/pxchfon0.def)
(/usr/local/texlive/2025/texmf-dist/tex/latex/pxufont/pxufont.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/ifptex/ifuptex.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/ifptex/ifptex.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/iftex/iftex.sty)))))
(/usr/local/texlive/2025/texmf-dist/tex/latex/geometry/geometry.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/iftex/ifvtex.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/hyperref.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/kvsetkeys/kvsetkeys.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/kvdefinekeys/kvdefinekeys.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/pdfescape/pdfescape.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/ltxcmds/ltxcmds.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/pdftexcmds/pdftexcmds.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/infwarerr/infwarerr.sty)))
(/usr/local/texlive/2025/texmf-dist/tex/latex/hycolor/hycolor.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/nameref.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/refcount/refcount.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/gettitlestring/gettitlestring.s
ty (/usr/local/texlive/2025/texmf-dist/tex/latex/kvoptions/kvoptions.sty)))
(/usr/local/texlive/2025/texmf-dist/tex/generic/stringenc/stringenc.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/pd1enc.def)
(/usr/local/texlive/2025/texmf-dist/tex/generic/intcalc/intcalc.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/puenc.def)
(/usr/local/texlive/2025/texmf-dist/tex/generic/bitset/bitset.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/bigintcalc/bigintcalc.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/base/atbegshi-ltx.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/hdvipdfm.def
(/usr/local/texlive/2025/texmf-dist/tex/latex/rerunfilecheck/rerunfilecheck.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/base/atveryend-ltx.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/uniquecounter/uniquecounter.sty
)))
(/usr/local/texlive/2025/texmf-dist/tex/latex/l3backend/l3backend-dvipdfmx.def)
 (./main.aux)
*geometry* detected driver: dvipdfm

Package hyperref Warning: Rerun to get /PageLabels entry.

(/usr/local/texlive/2025/texmf-dist/tex/latex/amsfonts/umsa.fd)
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsfonts/umsb.fd)
No file main.toc.

[1]

LaTeX Warning: Reference `eq:circle' on page 2 undefined on input line 68.


[2]
[3] (./main.aux)

LaTeX Warning: There were undefined references.


LaTeX Warning: Label(s) may have changed. Rerun to get cross-references right.


Package rerunfilecheck Warning: File `main.out' has changed.
(rerunfilecheck)                Rerun to get outlines right
(rerunfilecheck)                or use package `bookmark'.

 )
Output written on main.dvi (3 pages, 10628 bytes).
Transcript written on main.log.
Latexmk: Getting log file 'main.log'
Latexmk: Examining 'main.fls'
Latexmk: Examining 'main.log'
Latexmk: References changed.
Latexmk: References changed.
Latexmk: References changed.
Latexmk: Log file says output to 'main.dvi'
Latexmk: applying rule 'latex'...
Rule 'latex':  Reasons for rerun
Changed files or newly in use/created:
  main.aux
  main.out
  main.toc

------------
Run number 2 of rule 'latex'
------------
------------
Running 'uplatex -halt-on-error -interaction=nonstopmode  -recorder  "main.tex"'
------------
This is e-upTeX, Version 3.141592653-p4.1.2-u2.00-250202-2.6 (utf8.uptex) (TeX Live 2025) (preloaded format=uplatex)
 restricted \write18 enabled.
entering extended mode
(./main.tex
pLaTeX2e <2023-02-14u04>+1, based on
LaTeX2e <2024-11-01> patch level 2
L3 programming layer <2025-01-18>
(/usr/local/texlive/2025/texmf-dist/tex/platex/jsclasses/jsarticle.cls
Document Class: jsarticle 2023/02/23 jsclasses (okumura, texjporg)
(/usr/local/texlive/2025/texmf-dist/tex/platex/jsclasses/jslogo.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics/graphicx.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics/keyval.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics/graphics.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics/trig.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics-cfg/graphics.cfg)
(/usr/local/texlive/2025/texmf-dist/tex/latex/graphics-def/dvipdfmx.def)))
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amsmath.sty
For additional information on amsmath, use the `?' option.
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amstext.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amsgen.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amsbsy.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsmath/amsopn.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsfonts/amssymb.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsfonts/amsfonts.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/url/url.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/enumitem/enumitem.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/base/textcomp.sty)
(/usr/local/texlive/2025/texmf-dist/tex/platex/japanese-otf/otf.sty
(/usr/local/texlive/2025/texmf-dist/tex/platex/japanese-otf/ajmacros.sty))
(/usr/local/texlive/2025/texmf-dist/tex/platex/pxchfon/pxchfon.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/etoolbox/etoolbox.sty)
(/usr/local/texlive/2025/texmf-dist/tex/platex/pxchfon/pxchfon0.def)
(/usr/local/texlive/2025/texmf-dist/tex/latex/pxufont/pxufont.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/ifptex/ifuptex.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/ifptex/ifptex.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/iftex/iftex.sty)))))
(/usr/local/texlive/2025/texmf-dist/tex/latex/geometry/geometry.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/iftex/ifvtex.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/hyperref.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/kvsetkeys/kvsetkeys.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/kvdefinekeys/kvdefinekeys.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/pdfescape/pdfescape.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/ltxcmds/ltxcmds.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/pdftexcmds/pdftexcmds.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/infwarerr/infwarerr.sty)))
(/usr/local/texlive/2025/texmf-dist/tex/latex/hycolor/hycolor.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/nameref.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/refcount/refcount.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/gettitlestring/gettitlestring.s
ty (/usr/local/texlive/2025/texmf-dist/tex/latex/kvoptions/kvoptions.sty)))
(/usr/local/texlive/2025/texmf-dist/tex/generic/stringenc/stringenc.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/pd1enc.def)
(/usr/local/texlive/2025/texmf-dist/tex/generic/intcalc/intcalc.sty)
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/puenc.def)
(/usr/local/texlive/2025/texmf-dist/tex/generic/bitset/bitset.sty
(/usr/local/texlive/2025/texmf-dist/tex/generic/bigintcalc/bigintcalc.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/base/atbegshi-ltx.sty))
(/usr/local/texlive/2025/texmf-dist/tex/latex/hyperref/hdvipdfm.def
(/usr/local/texlive/2025/texmf-dist/tex/latex/rerunfilecheck/rerunfilecheck.sty
(/usr/local/texlive/2025/texmf-dist/tex/latex/base/atveryend-ltx.sty)
(/usr/local/texlive/2025/texmf-dist/tex/generic/uniquecounter/uniquecounter.sty
)))
(/usr/local/texlive/2025/texmf-dist/tex/latex/l3backend/l3backend-dvipdfmx.def)
 (./main.aux)
*geometry* detected driver: dvipdfm
(./main.out) (./main.out)
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsfonts/umsa.fd)
(/usr/local/texlive/2025/texmf-dist/tex/latex/amsfonts/umsb.fd) (./main.toc)
[1]
[2]
[3] (./main.aux) )
Output written on main.dvi (3 pages, 15964 bytes).
Transcript written on main.log.
Latexmk: Getting log file 'main.log'
Latexmk: Examining 'main.fls'
Latexmk: Examining 'main.log'
Latexmk: Log file says output to 'main.dvi'
Latexmk: applying rule 'dvipdf'...
Rule 'dvipdf':  Reasons for rerun
Changed files or newly in use/created:
  main.dvi
Category 'changed_source_rules':
  latex
Category 'no_dest':
  dvipdf

------------
Run number 1 of rule 'dvipdf'
------------
------------
Running 'dvipdfmx  -o "main.pdf" "main.dvi"'
------------
Latexmk: All targets (main.dvi main.pdf) are up-to-date → Rc files read:
  /Users/toshi/.latexmkrc
  .latexmkrc
Latexmk: This is Latexmk, John Collins, 27 Dec. 2024. Version 4.86a.
Latexmk: Nothing to do for 'main.tex'.
Latexmk: All targets (main.dvi main.pdf) are up-to-date
- オプションは不適切で、適切に設定されたlatexmkでは不要
- README.mdとCLAUDE.mdの両方で一貫性を保持

### 修正理由
- latexmkは設定ファイル（.latexmkrcまたはlatexmkrc）で出力形式を指定するのが標準
- は古い形式で、現在の環境では推奨されない
- より簡潔で正確な使用方法に修正

## 影響範囲
- 文書内のlatexmk使用例のみ（実際のビルドには影響なし）
- GitHub Actionsは変更なし（uplatex + dvipdfmx使用）