### PR TITLE
Fix latexmk option and update setup script syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ```bash
 # 汎用LaTeX文書用の自動セットアップ
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup-latex.sh)"
+DOC_TYPE=latex /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
 ```
 
 **自動セットアップの特徴**:


### PR DESCRIPTION
## Summary
- Fix latexmk option issue in configuration
- Update README setup command to use DOC_TYPE=latex environment variable
- Align with unified setup.sh script that uses environment variables

## Test plan
- [x] Verify DOC_TYPE=latex syntax matches setup.sh implementation
- [x] Confirm latexmk fixes work correctly
- [x] Check consistency with other template repositories