### PR TITLE
Remove inline comment from setup command for better copy-paste experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 [thesis-management-tools](https://github.com/smkwlab/thesis-management-tools)の自動セットアップスクリプトを使用：
 
 ```bash
-# 汎用LaTeX文書用の自動セットアップ
 DOC_TYPE=latex /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)"
 ```
 


### PR DESCRIPTION
## Summary
- Remove inline comment from bash command to improve copy-paste usability
- Align with other template repositories for consistent user experience

## Test plan
- [x] Verify setup command can be copied and executed without manual cleanup
- [x] Confirm documentation consistency across ecosystem