### PR TITLE
Add -synctex=1 and -file-line-error to .latexmkrc

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,4 +1,4 @@
-$latex = 'uplatex -halt-on-error -interaction=nonstopmode';
+$latex = 'uplatex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
 $bibtex = 'upbibtex';
 $dvipdf = 'dvipdfmx %O -o %D %S';
 $makeindex = 'upmendex %O -o %D %S';


### PR DESCRIPTION
## 概要

汎用 LaTeX テンプレートの `.latexmkrc` をエコシステム共通の指定に揃えます。

> **方針変更の経緯**: 当初は platex への変更を予定していましたが、テンプレート本体（`main.tex` の `jsarticle` の `uplatex` クラスオプション）や README が uplatex 前提であり、platex 化は整合コストが高いと判断しました。**エンジンは uplatex のまま**とし、他の uplatex 系テンプレート（sotsuron-template / wr-template など）と統一します。

## 変更内容

エンジン（uplatex）・bibtex（upbibtex）・makeindex（upmendex）・`-halt-on-error`・`pdf_mode` は元から共通設定のため、今回の実変更は **`-synctex=1` と `-file-line-error` の追加のみ**です。

```perl
$latex = 'uplatex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
$bibtex = 'upbibtex';
$dvipdf = 'dvipdfmx %O -o %D %S';
$makeindex = 'upmendex %O -o %D %S';
$pdf_mode = 3;
```

| オプション | 役割 |
|---|---|
| `-synctex=1` | VSCode LaTeX Workshop の PDF↔ソース相互ジャンプ |
| `-file-line-error` | エラー位置（`file:line:`）の特定を容易に |

## 動作確認

ローカルでクリーンビルド確認済み（TeX Live 2026 / uplatex）:
- exit 0
- `main.pdf`（3ページ）生成
- `main.synctex.gz` 生成

## 補足

- `main.tex`・README・CLAUDE.md はいずれも uplatex 前提のまま変更不要です（diff は `.latexmkrc` のみ）。
- `-interaction=nonstopmode` の CI 側との二重指定回避は共有ワークフロー `smkwlab/.github` の改修が必要なため、別途対応します。