### PR TITLE
Harden CI workflows to not depend on default token permissions

### DIFF
--- a/.github/workflows/create-next-draft.yml
+++ b/.github/workflows/create-next-draft.yml
@@ -7,4 +7,7 @@ on:
 
 jobs:
   create-next:
-    uses: smkwlab/.github/.github/workflows/create-next-draft.yml@main
+    uses: smkwlab/.github/.github/workflows/create-next-draft.yml@v1
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -2,13 +2,15 @@
 name: Build and Release PDF
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     tags:
       - '*'
 
 jobs:
   build:
-    uses: smkwlab/.github/.github/workflows/latex-build.yml@main
+    uses: smkwlab/.github/.github/workflows/latex-build.yml@v1
+    permissions:
+      contents: write
     with:
       files: "main, appendix, slide, report"

--- a/.github/workflows/notify-ml-on-pr.yml
+++ b/.github/workflows/notify-ml-on-pr.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   notify:
-    uses: smkwlab/.github/.github/workflows/notify-ml-on-pr.yml@main
+    uses: smkwlab/.github/.github/workflows/notify-ml-on-pr.yml@v1
     secrets: inherit


### PR DESCRIPTION
## 概要

派生先リポジトリの既定トークン権限（`default_workflow_permissions`）に依存しないよう、CI ワークフローを堅牢化します。

resolve #32

## 背景

再利用WFを呼ぶ caller ジョブに `permissions:` を明示しておらず、リポジトリ既定トークン権限が `write` であることに暗黙依存していました。既定が read-only の派生先（例: `toshi0806/toshi-iot74`）では `latex-build` / `create-next-draft` が `startup_failure` になります。

`latex-release-action@v3` は PR 時にも prerelease（`<branch>-release`）を作成するため、PR ビルドでも `contents: write` が必要であることを entrypoint.sh で確認しています。

## 変更内容

- **最小権限の明示**
  - `latex-build.yml` の `build` ジョブ: `contents: write`
  - `create-next-draft.yml` の `create-next` ジョブ: `contents: write`, `pull-requests: write`
- **トリガ変更** `latex-build.yml`: `pull_request_target` → `pull_request`
  - 他テンプレ（sotsuron-template / sotsuron-report-template）と整合
  - セキュリティ向上（ベース文脈の書込トークン＋secrets付与を回避）
  - 再利用WFの `checkout` が ref 未指定のため、`pull_request` だと PR HEAD を正しくビルド（プレビューの正当性修正）
  - 本テンプレは自リポジトリのブランチ運用想定でフォーク前提でないため実害なし
- **タグ固定** 再利用WF参照を `@main` → `@v1`（安定タグ、sotsuron-template と整合）
  - `latex-build.yml`
  - `create-next-draft.yml`
  - `notify-ml-on-pr.yml`（追加対応。v1 タグにWFが存在することを確認済み）

これにより3ワークフローすべてが安定タグ `@v1` を参照します。

## 受け入れ条件の確認

- [x] 既定トークンが read-only の派生先でも `startup_failure` にならない（caller ジョブに明示権限を宣言）
- [x] 既存の smkwlab 配下の動作を壊さない（write 既定環境でも最小権限宣言は問題なく動作）

## CI 確認

- `build / Build LaTeX Documents and Create Release`: SUCCESS（`pull_request` トリガ・tag 双方）