### PR TITLE
Pin setup script URL to v1 moving tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ gh auth login
 
 #### 下川研学生向け
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)" bash latex
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash latex
 ```
+
+> 💡 `v1` は安定版（最新の v1 系）を指す移動タグです。最新の開発版を試す場合は URL の `v1` を `main` に置き換えてください。
 
 **実行手順:**
 1. 上記コマンドを実行（macOS のターミナルまたは Windows の WSL 内）
@@ -54,7 +56,7 @@ gh auth login
 
 #### それ以外の皆さん向け
 ```bash
-INDIVIDUAL_MODE=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/main/create-repo/setup.sh)" bash latex
+INDIVIDUAL_MODE=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash latex
 ```
 
 **実行手順:**


### PR DESCRIPTION
## 概要

リポジトリ作成コマンド（下川研学生向け・個人モードの2箇所）の取得元 URL を `main` から **`v1`（メジャー移動タグ）** に変更し、安定・再現可能なセットアップを使えるようにします。

## 背景

`smkwlab/thesis-management-tools` にバージョン固定機構（[#438](https://github.com/smkwlab/thesis-management-tools/issues/438)）と `v1` 移動タグを導入しました。

- `v1` は「最新の `v1.x.x` リリース」を指す移動タグ（GitHub Actions の `@v4` と同様）
- パッチ／マイナーリリースのたびに README を更新する必要はなく、**メジャー更新（`v1`→`v2`）のときだけ** URL を更新すればよい
- `…/v1/setup.sh` は内部 clone も正確なバージョンに固定されるため再現性も確保

## 変更内容

- `README.md`: セットアップコマンド2箇所の URL を `/main/` → `/v1/` に変更し、`v1` の意味と最新版（`main`）への切替方法を注記