### PR TITLE
Reference shared workflow instead of hardcoded versions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Note: The build requires a Japanese LaTeX distribution (like TeX Live with Japan
 ## Key Architecture
 
 - **main.tex**: The primary LaTeX source file using `jsarticle` document class
-- **GitHub Actions**: Automated build and release workflow using `ghcr.io/smkwlab/texlive-ja-textlint:2025b` Docker container via `smkwlab/latex-release-action@v2.2.0`
+- **GitHub Actions**: Automated build and release via the shared `smkwlab/.github` LaTeX build workflow (`latex-build.yml@v1`), which centrally pins the `texlive-ja-textlint` Docker image and `latex-release-action` version for the whole ecosystem
 - **Output**: Generates `main.pdf` (which is gitignored)
 
 ## Release Workflow


### PR DESCRIPTION
resolve #41

`CLAUDE.md:38` がハードコードしていた `texlive-ja-textlint:2025b` / `latex-release-action@v2.2.0` は陳腐化していました。さらに実際のワークフローは `smkwlab/.github/.github/workflows/latex-build.yml@v1`（共有ワークフロー）を使用しており、記述の前提（latex-release-action を直接参照）自体も実態と異なっていました。

具体版数のハードコードは再び陳腐化するため、**共有ワークフローが版数を一元管理する**旨の記述に変更し、drift の再発を恒久的に解消します（poster-template#20 と同方針）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)