### PR TITLE
docs: use short setup URL in student one-liners

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ gh auth login
 bash <(curl -fsSL https://repo-setup.smkwlab.net) latex
 ```
 
-> 💡 短縮 URL `https://repo-setup.smkwlab.net` は安定版（最新の v1 系）の setup.sh を配信します。最新の開発版を試す場合は `bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh) latex` を使用してください。
+> 💡 短縮 URL `https://repo-setup.smkwlab.net` は安定版（最新の v1 系）の setup.sh を配信します。
 
 **実行手順:**
 1. 上記コマンドを実行（macOS のターミナルまたは Windows の WSL 内）

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ gh auth login
 
 #### 下川研学生向け
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash latex
+bash <(curl -fsSL https://repo-setup.smkwlab.net) latex
 ```
 
-> 💡 `v1` は安定版（最新の v1 系）を指す移動タグです。最新の開発版を試す場合は URL の `v1` を `main` に置き換えてください。
+> 💡 短縮 URL `https://repo-setup.smkwlab.net` は安定版（最新の v1 系）の setup.sh を配信します。最新の開発版を試す場合は `bash <(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh) latex` を使用してください。
 
 **実行手順:**
 1. 上記コマンドを実行（macOS のターミナルまたは Windows の WSL 内）
@@ -56,7 +56,7 @@ gh auth login
 
 #### それ以外の皆さん向け
 ```bash
-INDIVIDUAL_MODE=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash latex
+INDIVIDUAL_MODE=true bash <(curl -fsSL https://repo-setup.smkwlab.net) latex
 ```
 
 **実行手順:**


### PR DESCRIPTION
## 概要

学生に案内する setup.sh 実行コマンドを、長い raw URL から短縮 URL `https://repo-setup.smkwlab.net` に統一します。student-repo-management・latex-ecosystem で完了済みの変更を latex-template にも反映するものです。

短縮 URL は smkwlab の v1 安定版 setup.sh を配信し、プロセス置換 `bash <(curl ...) latex` の形で実行できます。

## 変更内容

- `README.md` の学生向けワンライナー 2 箇所を短縮 URL + プロセス置換形式に置換
  - 下川研学生向け（46-47 行付近）
  - それ以外の皆さん向け（`INDIVIDUAL_MODE=true` 付き）
- いずれも末尾の文書タイプ引数 `latex` を保持し、`INDIVIDUAL_MODE=true` の先頭環境変数もそのまま維持
- 旧 `/bin/bash -c "$(curl ...)" bash latex` 形式の `bash`（$0 ダミー）はプロセス置換では不要のため削除
- 移動タグの注記を実態に合わせて書き換え（短縮 URL が最新の安定版 v1 を配信する旨を明記し、開発版の代替として `main` の raw URL を案内）

## 残した箇所

- 開発版案内の `main` raw URL: 短縮 URL は最新版のみを配信するため、開発版を試すための代替手段として意図的に残置
- `blob/main/docs/INSTALL-GH.md` へのリンク: gh CLI インストール手順の閲覧用ドキュメントリンクであり、setup.sh 実行とは無関係のため対象外