### PR TITLE
feat: complete the dormant draft PR review capability

### DIFF
--- a/.github/workflows/prevent-draft-merge.yml
+++ b/.github/workflows/prevent-draft-merge.yml
@@ -1,0 +1,12 @@
+---
+name: Prevent Draft Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # All draft PRs should be protected, not just PRs to main/review-branch
+    # The reusable workflow checks if the head branch is a draft pattern
+
+jobs:
+  prevent-merge:
+    uses: smkwlab/.github/.github/workflows/prevent-draft-merge.yml@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,23 @@ Note: The build requires a Japanese LaTeX distribution (like TeX Live with Japan
 - **GitHub Actions**: Automated build and release via the shared `smkwlab/.github` LaTeX build workflow (`latex-build.yml@v1`), which centrally pins the `texlive-ja-textlint` Docker image and `latex-release-action` version for the whole ecosystem
 - **Output**: Generates `main.pdf` (which is gitignored)
 
+## Review Workflow (draft PR cycle, optional)
+
+This template ships the same draft-cycle workflows as sotsuron-template /
+ise-report-template / poster-template, but they are **dormant by design**:
+the reusable workflows in `smkwlab/.github` guard on draft-named branches
+(`if: contains(head_ref, 'draft')`), so repositories that only use `main`
+are unaffected.
+
+- **create-next-draft.yml**: auto-creates the next draft branch when a draft PR is opened
+- **prevent-draft-merge.yml**: blocks accidental merges of draft PRs (draft PRs are closed, not merged)
+- **sync-next-draft.yml**: propagates suggestion commits to later draft branches
+
+To adopt the flow in a repository, create a `0th-draft` branch and open a PR
+to `main`. Repository initialization with `main` + `0th-draft` (plus
+auto-assign and branch protection) is handled by student-repo-management
+when the review flow is requested at creation time.
+
 ## Release Workflow
 
 The repository automatically builds and releases PDFs when:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ dvipdfmx main.dvi
 latexmk main.tex
 \`\`\`
 
+### 添削を受ける場合（draft PR サイクル・オプション）
+
+このテンプレートには、卒業論文・ポスターと同じ **Pull Request ベースの添削フロー**が組み込まれています。研究会予稿など教員の添削を受けたい文書では、以下の手順で有効になります（添削が不要な場合は、これまでどおり main ブランチで直接編集してください。draft 系ブランチを使わない限りこの仕組みは一切動作しません）：
+
+1. **`0th-draft` ブランチを作成**して切り替える（リポジトリに `0th-draft` が既にある場合はこの手順は不要）
+2. `main.tex` を編集して commit / push
+3. **`0th-draft` → `main` の Pull Request を作成**して添削を依頼
+   - PR 作成と同時に次稿用の `1st-draft` ブランチが自動作成される
+4. レビューコメントを確認し、`1st-draft` に切り替えて改稿を続け、再び PR を作成
+   - 以降 `2nd-draft`, `3rd-draft`... と必要なだけ繰り返す
+
+> **重要**: draft ブランチの PR は**マージせずクローズ**します（誤マージは自動でブロックされます）。
+> draft PR サイクルの共通ルールの全体像は
+> [STUDENT-WORKFLOW.md](https://github.com/smkwlab/latex-ecosystem/blob/main/docs/STUDENT-WORKFLOW.md)
+> を参照してください。
+
 #### 基本的な文書構造
 `main.tex` を編集して文書を作成：
 


### PR DESCRIPTION
## 概要

latex タイプへの PR レビューフロー対応(Phase 1 / 2 段構えの前半)。テンプレートには既に `create-next-draft.yml` / `sync-next-draft.yml` が入っていたため、欠けていた `prevent-draft-merge.yml` を追加して draft 3 点セットを完成させ、使い方を文書化します。

## 変更内容

- `.github/workflows/prevent-draft-merge.yml` を追加(poster/ise/sotsuron と同一の薄い caller)
- README: 「添削を受ける場合(draft PR サイクル・オプション)」節を追加。0th-draft を自分で作れば任意のリポジトリで(後からでも)フローを使えることを説明
- CLAUDE.md: Review Workflow セクションを追加(休眠設計の説明含む)

## 影響

**既存利用者への影響はありません。** smkwlab/.github の再利用 workflow は `if: contains(head_ref, 'draft')` で draft 系ブランチ以外では発火しないため、main 直接編集の使い方はそのまま動きます。

## 関連

- Phase 2(student-repo-management に `REVIEW_FLOW=true` オプトイン: 作成時の 0th-draft 初期化・auto-assign・ブランチ保護)は別 PR で続きます
- poster への導入(poster-template#25 / student-repo-management#540)と同系列の作業