### PR TITLE
docs: separate the README section from the preceding text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ This template is ideal for:
 - Course assignments and reports
 - Personal academic documents
 - Prototyping larger LaTeX documents
+
 ## Which README is shown where
 
 GitHub resolves READMEs in the order `.github/` -> root -> `docs/`, and


### PR DESCRIPTION
## 概要

`CLAUDE.md` の「Which README is shown where」節が、直前の箇条書きと空行なしで続いていたのを修正します。

## 背景

#49 でこの節を追記した際、ファイル末尾に改行がなかったため見出しが前の行に密着していました。Markdown としては見出しとして描画されますが、**箇条書きの直後**であるため描画系によってはリストの一部と解釈される余地があり、`poster-template` では空行が入っていて揃ってもいませんでした。

```diff
 - Prototyping larger LaTeX documents
+
 ## Which README is shown where
```

`wr-template` / `ise-report-template` にも同じ修正を入れています。
