### PR TITLE
ci: update latex-build caller

### DIFF
--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -1,4 +1,11 @@
----
+# Caller template: Build and Release PDF — calls the latex-build reusable
+# (all-PR build style: every listed document is built on each PR; a tag push
+# creates a release with the PDFs attached).
+# Distributed by scripts/distribute-workflow.sh as
+# .github/workflows/latex-build.yml in each target repository.
+# The FILES token is the comma-separated list of documents to build (without
+# .tex extension). It has no default on purpose: pass it explicitly, e.g.
+#   --var FILES="sotsuron, gaiyou, thesis, abstract"
 name: Build and Release PDF
 
 on:


### PR DESCRIPTION
Updates the shared `latex-build` workflow as a caller of `smkwlab/.github/.github/workflows/latex-build.yml@v1`.

ビルド対象は配布時に `--var FILES="..."` で明示指定します（`.tex` 拡張子なし・カンマ区切り。例: `--var FILES="sotsuron, gaiyou, thesis, abstract"`）。既定値は意図的にありません。対象リポジトリの文書構成に合わせて指定してください。