### PR TITLE
docs: use canonical draft branch and PR base wording

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -97,9 +97,10 @@ latexmk main.tex
 
 1. **`0th-draft` ブランチを作成**して切り替える（リポジトリに `0th-draft` が既にある場合はこの手順は不要）
 2. `main.tex` を編集して commit / push
-3. **`0th-draft` → `main` の Pull Request を作成**して添削を依頼
-   - PR 作成と同時に次稿用の `1st-draft` ブランチが自動作成される
-4. レビューコメントを確認し、`1st-draft` に切り替えて改稿を続け、再び PR を作成
+3. **`base: main` ← `compare: 0th-draft` の Pull Request を作成**して添削を依頼
+   - PR 作成と同時に次稿ブランチ（`0th-draft` の次は `1st-draft`）が自動作成される
+4. レビューコメントを確認し、自動作成された次稿ブランチに切り替えて改稿を続け、再び PR を作成
+   - **PR の base（マージ先）は前稿ブランチ**にする（例: `base: 0th-draft` ← `compare: 1st-draft`）。前の稿がない最初の `0th-draft` の PR だけ `base: main`
    - 以降 `2nd-draft`, `3rd-draft`... と必要なだけ繰り返す
 
 > **重要**: draft ブランチの PR は**マージせずクローズ**します（誤マージは自動でブロックされます）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,9 @@ are unaffected.
 - **sync-next-draft.yml**: propagates suggestion commits to later draft branches
 
 To adopt the flow in a repository, create a `0th-draft` branch and open a PR
-to `main`. Repository initialization with `main` + `0th-draft` (plus
+with `main` as its base. Later drafts use the previous draft branch as base
+(the PR from `1st-draft` has base `0th-draft`, and so on). Repository
+initialization with `main` + `0th-draft` (plus
 auto-assign and branch protection) is handled by student-repo-management
 when the review flow is requested at creation time.
 


### PR DESCRIPTION
## 背景

エコシステム全体で draft ブランチまわりの表記を統一する作業の一環（用語の正: smkwlab/latex-ecosystem#155）。

`.github/README.md`「添削を受ける場合」の手順が `1st-draft` リテラルで書かれており、2 周目以降に合わなかった。また `0th-draft` → `main` という矢印表記だけでは base の向きが読み取れず、draft PR の base 規則も書かれていなかった。

## 変更内容

- 「次稿用の `1st-draft` ブランチ」→「次稿ブランチ（`0th-draft` の次は `1st-draft`）」
- 「`1st-draft` に切り替えて改稿」→「自動作成された次稿ブランチに切り替えて改稿」
- **PR の base は前稿ブランチ**（最初の `0th-draft` のみ `main`）を明記
- PR の例示を `base: main` ← `compare: 0th-draft` 形式に統一（用語集の表記ルール）
- `CLAUDE.md`: 後続の稿の base が前稿ブランチであることを追記

## 確認事項

- base 規則は実際の学生 PR（`base: 1st-draft` の `2nd-draft` PR が多数）と一致することを確認済み
