### PR TITLE
docs: write the sample document in dearu style

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -36,7 +36,7 @@
 
 \section{はじめに}
 
-これは汎用的な日本語LaTeX文書のテンプレートです。研究ノート、レポート、実験記録など様々な用途に活用できます。
+これは汎用的な日本語LaTeX文書のテンプレートである。研究ノート、レポート、実験記録など様々な用途に活用できる。
 
 \subsection{このテンプレートの特徴}
 
@@ -51,25 +51,25 @@
 
 \subsection{文書の構成}
 
-文書は\texttt{section}と\texttt{subsection}で構成します。必要に応じて\texttt{subsubsection}も使用できます。
+文書は\texttt{section}と\texttt{subsection}で構成する。必要に応じて\texttt{subsubsection}も使用できる。
 
 \subsection{数式の記述}
 
-数式は以下のように記述できます。
+数式は以下のように記述できる。
 
-インライン数式: $E = mc^2$
+インライン数式は $E = mc^2$ のように書く。
 
-独立した数式:
+独立した数式は次のように書く。
 \begin{equation}
 (x - a)^2 + (y - b)^2 = r^2
 \label{eq:circle}
 \end{equation}
 
-式~\ref{eq:circle}は円の方程式です。
+式~\ref{eq:circle}は円の方程式である。
 
 \subsection{図表の挿入}
 
-図や表は\texttt{graphicx}パッケージを使用して挿入できます。
+図や表は\texttt{graphicx}パッケージを使用して挿入できる。
 
 % 図の例（コメントアウト）
 % \begin{figure}[htbp]
@@ -103,14 +103,14 @@
 
 \subsection{引用と参考文献}
 
-重要な内容は以下のように引用できます:
+重要な内容は以下のように引用できる。
 
 \begin{quote}
-ここに引用文を記述します。長い引用や重要な文章を強調する際に使用します。
+ここに引用文を記述する。長い引用や重要な文章を強調する際に使用する。
 \end{quote}
 
 \section{まとめ}
 
-このテンプレートを基に、目的に応じてカスタマイズしてください。LaTeX文書作成の効率向上に役立てていただければ幸いです。
+このテンプレートを基に、目的に応じて構成や設定を変更できる。必要な節だけを残し、不要な記述例は削除するとよい。
 
 \end{document}


### PR DESCRIPTION
## 問題

このテンプレートから作られたリポジトリには、aldc 経由で latex-environment の `.textlintrc` が入る。その設定は本文に である調 を要求している。

```json
"no-mix-dearu-desumasu": {
  "preferInBody": "である",
  "strict": true
}
```

一方 `main.tex` の見本は全編 ですます調 で書かれている。**見本が、同梱される lint 設定に違反している。**

これまで表面化していなかったのは `textlint-rule-no-mix-dearu-desumasu` v5 が検出していなかったため。同じ見本・同じ設定で v5 は 0 件、v6 は 11 件を報告する。texlive-ja-textlint 側でこのルールが v5 → v6 に上がるので（main に未配布の状態で滞留中）、配布された時点で、**新しくリポジトリを作った学生が 1 文字も書く前に 11 件の指摘を受ける**ことになる。

実際に latex 系の学生リポジトリ 4 件を確認したところ、すべて未編集でこの見本のままだった（`main.tex` とバイト一致）。

## 対応

見本の文章を である調 に書き換えた。あわせて数式節のラベル的な断片 2 箇所を文にした。

```diff
-これは汎用的な日本語LaTeX文書のテンプレートです。…活用できます。
+これは汎用的な日本語LaTeX文書のテンプレートである。…活用できる。

-インライン数式: $E = mc^2$
+インライン数式は $E = mc^2$ のように書く。

-独立した数式:
+独立した数式は次のように書く。
```

後者は `ja-no-mixed-period`（文末が「。」で終わっていない）の指摘で、**今回のルール更新とは無関係に新旧どちらでも出ていた**既存の指摘。見本の目的が「学生が書き始める前に指摘が出ないこと」である以上、あわせて解消した。

なお sotsuron-template と ise-report-template の見本は元から である調 で、新ルールでも `no-mix-dearu-desumasu` は 0 件。この問題は latex-template に限る。

## 検証

新旧両方のルールセットを実際に構築して、同じ設定で lint した。

```
変更前 (v6 ルール)  13 件   no-mix-dearu-desumasu:11  ja-no-mixed-period:2
変更後 (v6 ルール)   0 件
変更後 (v5 ルール)   0 件
```

ですます調 の残存も確認済み（`です。` `ます。` `でしょう` `ください` のいずれも無し）。

変更は文章のみでマクロ構造には触れていないが、PDF ビルドは CI の成否で確認する。

## 位置づけ

texlive-ja-textlint の `2026d` を切る前段。順序は次のとおり。

1. **この PR** — 見本を である調 に直す
2. texlive-ja-textlint で `2026d` を切ってイメージを publish
3. 消費者を `2026d` へ揃える（latex-environment の devcontainer は 2026c、latex-release-action の Dockerfile は 2026a で 2 世代遅れ）

実際に執筆された学生文書 3 本（日本語 13,236 文字）では、ルール更新の前後で指摘が行番号・メッセージまで完全に一致しており、既存の書き手への影響は無い。
